### PR TITLE
Add Syntax for Class and methods definitions, extend and implements classes (with/without comma)

### DIFF
--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -500,8 +500,7 @@ syntax match phpClassImplementsComma contained nextgroup=phpClassImplementsName 
 
 " Method name
 syn keyword phpKeyword function contained
-      \ nextgroup=phpDefineMethodName skipwhite skipempty
-
+      \ nextgroup=phpDefineMethodName contained skipwhite skipempty
 syn match phpDefineMethodName /\h\w*/
 
 " Clusters
@@ -606,8 +605,9 @@ if !exists("did_php_syn_inits")
   hi def link phpDefineClassName  phpClasses
 
   " I change this in order to display the color that I like
-  " Maybe this is pretty WTF but no one cares
-  hi def link phpInclude          Include
+  " Maybe this is dosn't make sense or is a really WTF
+  " but no one cares
+  hi def link phpInclude          Keyword
   hi def link phpKeyword          Keyword
 
   hi def link phpDefineExtendsName  String


### PR DESCRIPTION
Take a look at this screenshot https://www.dropbox.com/s/lffrcajn22h69a5/php.vim_highlighting.png
