### PR TITLE
Distinguish PHPDoc annotation arguments clearly

### DIFF
--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -535,13 +535,13 @@ syn match phpCommentStar contained "^\s*\*$"
 if !exists("php_ignore_phpdoc")
   syn case ignore
 
-  syn region phpDocComment   start="/\*\*" end="\*/" keepend contains=phpCommentTitle,phpDocTags,phpTodo,@Spell
+  syn region phpDocComment   start="/\*\*" end="\*/" keepend contains=phpCommentTitle,phpDocTags,phpTodo,@Spell,phpDocIdentifier
   syn region phpCommentTitle contained matchgroup=phpDocComment start="/\*\*" matchgroup=phpCommmentTitle keepend end="\.$" end="\.[ \t\r<&]"me=e-1 end="[^{]@"me=s-2,he=s-1 end="\*/"me=s-1,he=s-1 contains=phpCommentStar,phpTodo,phpDocTags,@Spell containedin=phpDocComment
 
   syn region phpDocTags  start="{@\(example\|id\|internal\|inheritdoc\|link\|source\|toc\|tutorial\)" end="}" containedin=phpDocComment
-  syn match  phpDocTags  "@\(abstract\|access\|author\|category\|copyright\|deprecated\|example\|exception\|filesource\|final\|global\|id\|ignore\|inheritdoc\|internal\|license\|link\|magic\|method\|name\|package\|param\|property\|return\|see\|since\|source\|static\|staticvar\|subpackage\|throws\|toc\|todo\|tutorial\|uses\|var\|version\)\s\+\S\+.*" contains=phpDocParam containedin=phpDocComment
-  syn match  phpDocParam "\s\S\+" contained contains=phpDocIdentifier
-  syn match  phpDocIdentifier contained "$\h\w*"
+  syn match  phpDocTags  "@\(abstract\|access\|author\|category\|copyright\|deprecated\|example\|exception\|filesource\|final\|global\|id\|ignore\|inheritdoc\|internal\|license\|link\|magic\|method\|name\|package\|param\|property\|return\|see\|since\|source\|static\|staticvar\|subpackage\|throws\|toc\|todo\|tutorial\|uses\|var\|version\)\s\+\S" contains=phpDocParam,phpDocIdentifier containedin=phpDocComment
+  syn match  phpDocParam "\s[^$]\S*" contained
+  syn match  phpDocIdentifier contained "\<$\h\w*\>"
 
   syn case match
 endif


### PR DESCRIPTION
The PHPDoc annotations match the current line greedily. In addition to this making annotation arguments (e.g. type specifiers) blend in with the rest of the line it is inconsistent with any continuation lines, which take the default comment colour. This makes the PHPDoc matching a little more sophisticated, so annotation arguments and identifiers stand out.

Actual vs. expected:
![phpdocparam](https://cloud.githubusercontent.com/assets/603326/3258018/6c6ca48a-f234-11e3-88e0-1fd9d8a78190.png)

This can arguably be simplified. In particular, line 18 in the screenshot takes steps to render the commas as comments rather than part of the identifier or annotation name. Since it's insane to use commas in identifier names, that complexity may not be necessary. A similar case can be made for line 21.
