### PR TITLE
Option refactoring

### DIFF
--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -596,10 +596,10 @@ syn region phpHereDoc matchgroup=Delimiter start=+\(<<<\)\@<="\z(\I\i*\)"$+ end=
 " including HTML,JavaScript,SQL if enabled via options
 if (exists("php_html_in_heredoc") && php_html_in_heredoc)
   syn region phpHereDoc matchgroup=Delimiter start="\(<<<\)\@<=\z(\(\I\i*\)\=\(html\)\c\(\i*\)\)$" end="^\z1\(;\=$\)\@="  contained contains=@htmlTop,phpIdentifier,phpIdentifierSimply,phpIdentifierComplex,phpSpecialChar,phpMethodsVar,phpStrEsc keepend extend
+  syn region phpHereDoc matchgroup=Delimiter start="\(<<<\)\@<=\z(\(\I\i*\)\=\(javascript\)\c\(\i*\)\)$" end="^\z1\(;\=$\)\@="  contained contains=@htmlJavascript,phpIdentifierSimply,phpIdentifier,phpIdentifierComplex,phpSpecialChar,phpMethodsVar,phpStrEsc keepend extend
 endif
 if (exists("php_sql_heredoc") && php_sql_heredoc)
   syn region phpHereDoc matchgroup=Delimiter start="\(<<<\)\@<=\z(\(\I\i*\)\=\(sql\)\c\(\i*\)\)$" end="^\z1\(;\=$\)\@=" contained contains=@sqlTop,phpIdentifier,phpIdentifierSimply,phpIdentifierComplex,phpSpecialChar,phpMethodsVar,phpStrEsc keepend extend
-  syn region phpHereDoc matchgroup=Delimiter start="\(<<<\)\@<=\z(\(\I\i*\)\=\(javascript\)\c\(\i*\)\)$" end="^\z1\(;\=$\)\@="  contained contains=@htmlJavascript,phpIdentifierSimply,phpIdentifier,phpIdentifierComplex,phpSpecialChar,phpMethodsVar,phpStrEsc keepend extend
 endif
 syn case ignore
 


### PR DESCRIPTION
Went ahead and did what was discussed in issue #8.

There's now a few new options:
- `php_sql_heredoc` - indicate whether highlight SQL in heredocs.  Defaults true.
- `php_html_in_heredoc` - indicate whether to highlight HTML in heredocs.  Defaults true.
- `php_html_load` - indicate whether to load HTML syntax file at all.  If false, the HTML syntax file isn't loaded and no HTML syntax highlighting will occur.  This will force `php_html_in_strings` and `php_html_in_heredoc` to false and turn off highlighting outside of `<?php ?>` tags.  Defaults true.

All of the options have defaults that produce the current behavior so people who update won't see a change unless they want to.

I noticed a couple of options didn't have descriptions in the docs, so I added some based on what I guessed they did.

I also consolidated the folding option explanations as I felt they were a little confusing being split apart.
