### PR TITLE
Fixed bug with highlighting things in closures.

### DIFF
--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -631,8 +631,8 @@ syn case ignore
 " Parent
 if (exists("php_parent_error_close") && php_parent_error_close) || (exists("php_parent_error_open") && php_parent_error_open)
   syn match  phpParent "[{}]"  contained
-  syn region phpParent matchgroup=Delimiter start="(" end=")"  contained contains=@phpClFunction transparent
-  syn region phpParent matchgroup=Delimiter start="\[" end="\]"  contained contains=@phpClInside transparent
+  syn region phpParent matchgroup=Delimiter start="(" end=")"  contained contains=@phpClFunction,@phpClControl transparent
+  syn region phpParent matchgroup=Delimiter start="\[" end="\]"  contained contains=@phpClFunction,@phpClControl transparent
   if ! (exists("php_parent_error_close") && php_parent_error_close)
     syn match phpParent "[\])]" contained
   endif


### PR DESCRIPTION
Naturally the first file I open after my previous PR was merged is one containing closures, something I'd forgotten PHP added (even though they've been there since 5.3).

The issue was that the regions defined for `[ ]` and `( )` pairs (`phpParent`) didn't contain the new cluster I created for the folded control structures (`@phpClControl`).  

Since PHP 5.4 it's been possible to define arrays using the `[ ]` syntax, which means closures (and therefor control structures) can now be present inside `[ ]`s.  To account for this, I add the `@phpClFunction` and `@phpClControl` clusters to that region's `contains=` list and removed `@phpClInside` since that's contained in `@phpClFunction`.

Thanks for your help and patience with these pull requests, this has been a great learning experience for me and something I've wanted to learn for a while.
