### PR TITLE
Only match first identifier in doc tag

### DIFF
--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -577,13 +577,13 @@ syn match phpCommentStar contained "^\s*\*$"
 if !exists("php_ignore_phpdoc")
   syn case ignore
 
-  syn region phpDocComment   start="/\*\*" end="\*/" keepend contains=phpCommentTitle,phpDocTags,phpTodo,@Spell,phpDocIdentifier
+  syn region phpDocComment   start="/\*\*" end="\*/" keepend contains=phpCommentTitle,phpDocTags,phpTodo,@Spell
   syn region phpCommentTitle contained matchgroup=phpDocComment start="/\*\*" matchgroup=phpCommmentTitle keepend end="\.$" end="\.[ \t\r<&]"me=e-1 end="[^{]@"me=s-2,he=s-1 end="\*/"me=s-1,he=s-1 contains=phpCommentStar,phpTodo,phpDocTags,@Spell containedin=phpDocComment
 
   syn region phpDocTags  start="{@\(example\|id\|internal\|inheritdoc\|link\|source\|toc\|tutorial\)" end="}" containedin=phpDocComment
-  syn match  phpDocTags  "@\(abstract\|access\|author\|category\|copyright\|deprecated\|example\|exception\|filesource\|final\|global\|id\|ignore\|inheritdoc\|internal\|license\|link\|magic\|method\|name\|package\|param\|property\|return\|see\|since\|source\|static\|staticvar\|subpackage\|throws\|toc\|todo\|tutorial\|uses\|var\|version\)\s\+\S" contains=phpDocParam,phpDocIdentifier containedin=phpDocComment
-  syn match  phpDocParam "\s[^$]\S*" contained
-  syn match  phpDocIdentifier contained "\<$\h\w*\>"
+  syn match phpDocTags "@\%(abstract\|access\|author\|category\|copyright\|deprecated\|example\|exception\|filesource\|final\|global\|id\|ignore\|inheritdoc\|internal\|license\|link\|magic\|method\|name\|package\|param\|property\|return\|see\|since\|source\|static\|staticvar\|subpackage\|throws\|toc\|todo\|tutorial\|uses\|var\|version\)" containedin=phpDocComment nextgroup=phpDocParam,phpDocIdentifier
+  syn match phpDocParam "\s\+\%(\h\w*|\?\)\+" nextgroup=phpDocIdentifier
+  syn match phpDocIdentifier "\s\+$\h\w*"
 
   syn case match
 endif


### PR DESCRIPTION
Well. That took a lot longer to find time for than anticipated.

This follows up on #19 by matching only the first identifier, and only if it occurs as the first or second argument and is preceded by at least one whitespace character.

I could not get the `\@<=` construct to work in the syntax file even though it worked in manual searches. I would have preferred to use that for the preceding `\s` in lines 585 and 586.

![screenshot from 2014-07-18 12 32 44](https://cloud.githubusercontent.com/assets/603326/3625175/fa263ea0-0e66-11e4-94ad-a7047836dd2b.png)
