### PR TITLE
Updated repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you don't have a preferred installation method, [pathogen.vim](https://github
 
 ```bash
 cd ~/.vim/bundle
-git clone git@github.com:StanAngeloff/php.vim.git
+git clone https://github.com/StanAngeloff/php.vim.git
 ```
 
 Configuration


### PR DESCRIPTION
`git clone git@github.com:StanAngeloff/php.vim.git` does not work for users who have not configured SSH and github to work this way. It results in `Permission denied (publickey).`

Clone over HTTPS works for anyone who hits the page.