### PR TITLE
Fix highlighting of periods in phpDocComment

### DIFF
--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -596,7 +596,7 @@ if !exists("php_ignore_phpdoc") || !php_ignore_phpdoc
   syn case ignore
 
   SynFoldDoc syn region phpDocComment   start="/\*\*" end="\*/" keepend contains=phpCommentTitle,phpDocTags,phpTodo,@Spell
-  syn region phpCommentTitle contained matchgroup=phpDocComment start="/\*\*" matchgroup=phpCommmentTitle keepend end="\.$" end="\.[ \t\r<&]"me=e-1 end="[^{]@"me=s-2,he=s-1 end="\*/"me=s-1,he=s-1 contains=phpCommentStar,phpTodo,phpDocTags,@Spell containedin=phpDocComment
+  syn region phpCommentTitle contained matchgroup=phpDocComment start="/\*\*" matchgroup=phpCommentTitle keepend end="\.$" end="\.[ \t\r<&]"me=e-1 end="[^{]@"me=s-2,he=s-1 end="\*/"me=s-1,he=s-1 contains=phpCommentStar,phpTodo,phpDocTags,@Spell containedin=phpDocComment
 
   syn region phpDocTags  start="{@\(example\|id\|internal\|inheritdoc\|link\|source\|toc\|tutorial\)" end="}" containedin=phpDocComment
   syn match phpDocTags "@\%(abstract\|access\|api\|author\|brief\|bug\|category\|class\|copyright\|created\|date\|deprecated\|details\|example\|exception\|file\|filesource\|final\|global\|id\|ignore\|inheritdoc\|internal\|license\|link\|magic\|method\|name\|package\|param\|property\|return\|see\|since\|source\|static\|staticvar\|struct\|subpackage\|throws\|toc\|todo\|tutorial\|type\|uses\|var\|version\|warning\)" containedin=phpDocComment nextgroup=phpDocParam,phpDocIdentifier skipwhite


### PR DESCRIPTION
Hi there - I've been using this script for a while, but somehow only recently noticed that if I had a period anywhere in a DocBlock comment, it would be highlighted differently from the rest of the comment. I tracked this down to a misspelling of the name of the `phpCommentTitle` highlight group.

### before:
![docblock_before](https://cloud.githubusercontent.com/assets/752281/8850411/eff7b990-3115-11e5-9876-12780ffd0b19.png)

### after:
![docblock_after](https://cloud.githubusercontent.com/assets/752281/8850412/effe6fa6-3115-11e5-821d-8e37a659494b.png)

phpCommentTitle is linked to phpComment by default, but I don't think this will change anything substantial for users who might have phpCommentTitle highlighted differently.