### PR TITLE
Support "use function" properly. Fixes #42.

### DIFF
--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -682,7 +682,7 @@ syntax match phpClassDelimiter contained
 " Function name
 syn keyword phpKeyword function contained
       \ nextgroup=phpFunction skipwhite skipempty
-syn match phpFunction /\h\w*/
+syn match phpFunction /\(use\sfunction\s*\)\@<!\h\w*/
 
 " Clusters
 syn cluster phpClConst contains=phpFunctions,phpClasses,phpStaticClasses,phpIdentifier,phpStatement,phpKeyword,phpOperator,phpSplatOperator,phpStringSingle,phpStringDouble,phpBacktick,phpNumber,phpType,phpBoolean,phpStructure,phpMethodsVar,phpConstants,phpException,phpSuperglobals,phpMagicConstants,phpServerVars


### PR DESCRIPTION
![Works on my machine!](http://blog.codinghorror.com/content/images/uploads/2007/03/6a0120a85dcdae970b0128776ff992970c-pi.png)

I used regex negative lookbehind, couldn't figure out how to do syntax blacklisting.