### PR TITLE
Add php 7.1 types as a valid types

### DIFF
--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -522,7 +522,7 @@ syn keyword phpKeyword die exit eval empty isset unset list instanceof insteadof
 syn keyword phpInclude include include_once require require_once namespace contained
 
 " Types
-syn keyword phpType bool[ean] int[eger] real double float string array object null self parent global this stdClass callable contained
+syn keyword phpType bool[ean] int[eger] real double float string array object null self parent global this stdClass callable iterable void contained
 
 " Operator
 syn match phpOperator       "[-=+%^&|*!.~?:]" contained display


### PR DESCRIPTION
I didn't add the support of `nullable` types (`?` prefix) because I am not sure if this was needed ; it is quite distinguishable, because it "pops" and I think it is a good thing, rather than registering it as a type. And also because my knowledge in vim coloration is limited too, and I didn't want to duplicate the types line with the `?` as I think there is a prettier way to do that.

Some other things are probably missing though...