### PR TITLE
change "class keywords" from `phpType` to `phpKeyword`

### DIFF
--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -523,7 +523,7 @@ if php_folding != 1
 endif
 
 " Class Keywords
-syn keyword phpType class abstract extends interface implements static final var public private protected const trait contained
+syn keyword phpKeyword class abstract extends interface implements static final var public private protected const trait contained
 
 " Magic Methods
 syn keyword phpStatement __construct __destruct __call __callStatic __get __set __isset __unset __sleep __wakeup __toString __invoke __set_state __clone contained


### PR DESCRIPTION
Closes #81